### PR TITLE
Adding a warning for --pre option for pip 1.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,10 @@ Installation
 	* From the Python Package Index
 
 		pip install PyPDS
+		(Note that starting from pip version >= 1.4 you need to include the --pre(-release) 
+		option because of PyPDS' non-standard versioning scheme.
+		So, use: 
+		pip install --pre PyPDS
 
 	* From the GitHub repository
 

--- a/README.rst
+++ b/README.rst
@@ -39,9 +39,11 @@ Installation
 	* From the Python Package Index
 
 		pip install PyPDS
-		(Note that starting from pip version >= 1.4 you need to include the --pre(-release) 
+		
+		Note that starting from pip version >= 1.4 you need to include the --pre(-release) 
 		option because of PyPDS' non-standard versioning scheme.
 		So, use: 
+		
 		pip install --pre PyPDS
 
 	* From the GitHub repository


### PR DESCRIPTION
Since pip 1.4 one requires a --pre option for the install of PyPDS, something to do with their definition of version numbering schemes.
