### PR TITLE
update to work in Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ src/doc/.build/
 *.pyc
 *.log
 *.IMG
+build/
+PyPDS.egg-info/top_level.txt
+PyPDS.egg-info/SOURCES.txt
+PyPDS.egg-info/PKG-INFO

--- a/pds/__init__.py
+++ b/pds/__init__.py
@@ -7,6 +7,6 @@ Created by Ryan Matthew Balfanz on 2009-05-28.
 Copyright (c) 2009 Ryan Matthew Balfanz. All rights reserved.
 """
 
-from core import *
+from .core import *
 
 __all__ = ['core', 'imageextractor']

--- a/pds/core/__init__.py
+++ b/pds/core/__init__.py
@@ -7,10 +7,10 @@ Created by Ryan Matthew Balfanz on 2009-05-28.
 Copyright (c) 2009 Ryan Matthew Balfanz. All rights reserved.
 """
 
-from common import *
-from reader import *
-from parser import *
-from extractorbase import *
+from .common import *
+from .reader import *
+from .parser import *
+from .extractorbase import *
 
 __all__ = ['reader', 'parser', 'extractorbase']
   

--- a/pds/core/common.py
+++ b/pds/core/common.py
@@ -48,7 +48,7 @@ def open_pds(source):
 	# if isinstance(source, file):
 	# 	return source
 	if hasattr(source, "read"):
-		# sys.stderr.write("Identified a file-like object by read() method existence\n")
+		#sys.stderr.write("Identified a file-like object by read() method existence\n")
 		return source
 
 	try:
@@ -57,6 +57,12 @@ def open_pds(source):
 		# PDS style newlines are "\r\n", however, http://pds.jpl.nasa.gov/documents/qs/sample_image.lbl uses "\n".
 		# Check if hasattr(open, 'newlines') to verify that universal newline support is enabeled.
 		f = open(source, "rb")
+
+		#reading the file as a byte-like object. Try to decode if necessary
+		try:
+			f = f.decode('utf-8')
+		except(UnicodeDecodeError, AttributeError):
+			pass
 		return f
 	except (IOError, OSError):
 		# sys.stderr.write("Could not open source\n")

--- a/pds/core/parser.py
+++ b/pds/core/parser.py
@@ -19,7 +19,7 @@ import sys
 import unittest
 
 #from common import open_pds
-from reader import Reader
+from .reader import Reader
 
 
 class ParserError(Exception):
@@ -184,7 +184,7 @@ class ParserTests(unittest.TestCase):
 				try:
 					labels = pdsparser.parse(open_pds(filename))
 					# labels = pdsparser.labels # Old usage, depriciated.
-				except Exception, e:
+				except Exception as e:
 					# Re-raise the exception, causing this test to fail.
 					raise
 				else:
@@ -200,5 +200,5 @@ if __name__ == '__main__':
 	pdsparser = Parser()
 	labels = pdsparser.parse(open_pds(filename))
 	# labels = pdsparser.labels # Old usage, depriciated.
-	print labels.keys()
-	print labels['IMAGE END']
+	print(labels.keys())
+	print(labels['IMAGE END'])

--- a/pds/core/reader.py
+++ b/pds/core/reader.py
@@ -137,10 +137,18 @@ class Reader(object):
 		if self.log: self.log.debug('Tonekization')
 		tokens = []
 		for i, line in enumerate(source):
+			#decode if this is a bytes-like object
+			try:
+				line = line.decode('utf-8')
+			except(UnicodeDecodeError, AttributeError):
+				pass
+
 		#for i, line in enumerate(it):
 			line = line.strip()
+			print(line)
 			if not line:
 				continue
+
 			elif commentStart.match(line):
 				if not commentEnd.search(line):
 					if self.log: self.log.warn("Detected possible multiline comment near line %d" % i)
@@ -163,7 +171,7 @@ class Reader(object):
 			dataStartIndex = recIndx + 1
 			try:
 				dataEndIndex = recordIndicies[i + 1] - 1
-			except IndexError, e:
+			except IndexError as  e:
 				errorMessage = 'i: %d, Number of tokens: %d' % (i, len(tokens))
 				assert i == (len(recordIndicies) - 1), errorMessage
 				dataEndIndex = len(tokens) - 1
@@ -204,7 +212,7 @@ class ReaderTests(unittest.TestCase):
 					for record in pdsreader.read(open_pds(filename)):
 						#print record
 						pass
-				except Exception, e:
+				except Exception as e:
 					# Re-raise the exception, causing this test to fail.
 					raise
 				else:


### PR DESCRIPTION
implemented absolute references to packages and syntax updates to work in Python 3 (print, try/except calls, parsing of byte-like objects)